### PR TITLE
メッセージ保存と表示

### DIFF
--- a/components/ChatForm.vue
+++ b/components/ChatForm.vue
@@ -1,16 +1,33 @@
 <template>
     
         <div class="input-container">
-            <textarea v-on:click="login"></textarea>
+            <textarea v-model="text" v-on:keydown.enter="addMessage"></textarea>
         </div>
     
 </template>
 <script>
+import { db } from '~/plugins/firebase'
+
 export default {
-    methods: {
-        login() {
-            window.alert('ログインしろよ')
+    data() {
+        return {
+            text: null
         }
+    },
+    methods: {
+        addMessage() {
+            if (this.keyDownedForJPConversion(event)) { return }
+            const channelId = this.$route.params.id
+            db.collection('channels').doc(channelId).collection('messages').add({text: this.text})
+                .then(() => {
+                    this.text = null
+                })
+        },
+        keyDownedForJPConversion (event) {
+            const codeForConversion = 229
+            return event.keyCode === codeForConversion
+        }
+
     }
 }
 </script>

--- a/components/Message.vue
+++ b/components/Message.vue
@@ -1,27 +1,17 @@
 <template>
     <div class="chat-container">
-        <div class="thumbnail-container">
+        <!-- <div class="thumbnail-container">
             <img v-bind:src="message.user.thumbnail" />
-        </div>
+        </div> -->
         <div class="message-container">
-            <div class="user-name">{{ displayName }}</div>
+            <!-- <div class="user-name">{{ displayName }}</div> -->
             <div class="message">{{ message.text}}</div>
         </div>
     </div>
 </template>
 <script>
 export default {
-    data() {
-        return {
-            message: {
-                text: '今日もいい天気ですね',
-                user: {
-                    thumbnail: 'https://pakutaso.cdn.rabify.me/shared/img/thumb/PAK86_kononihonwokae20140713.jpg.webp?d=350',
-                    name: 'note'
-                }
-            } 
-        }
-    },
+    props: ['message'],
     computed: {
         displayName() {
             return "@" + this.message.user.name

--- a/components/Messages.vue
+++ b/components/Messages.vue
@@ -1,35 +1,15 @@
 <template>
     <div class="chats-container">
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
-        <message />
+        <message v-for="message in messages" :message="message"/>
     </div>
 </template>
 <script>
 import Message from '~/components/Message'
 export default {
+    props: ['messages'],
     components: {
         Message
-    }
+    },
 }
 </script>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,7 +27,6 @@ export default {
       querySnapshot.forEach((doc) => {
         this.channels.push({id: doc.id, ...doc.data()})
       })
-      console.log(this.channels)
     })
   }
 }

--- a/pages/channels/_id.vue
+++ b/pages/channels/_id.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="container">
         <div class="chats-layout">
-            <messages />
+            <messages :messages="messages"/>
         </div>
         <div class="input-layout">
             <chat-form />
@@ -20,6 +20,20 @@ components: {
     Messages,
     ChatForm
 },
+data() {
+    return {
+        messages: []
+    }
+},
+mounted() {
+    const channelId = this.$route.params.id
+    db.collection('channels').doc(channelId).collection('messages').get()
+        .then((querySnapshot) => {
+            querySnapshot.forEach((doc) => {
+                this.messages.push({id: doc.id, ...doc.data()})
+            })
+        })
+}
 }
 </script>
 


### PR DESCRIPTION
・firestoreでchannel配下にmessageコレクションとダミーデータを作成
・_id.vue でmessageコレクションとダミーデータを取得
   messagesとして、コンポーネントmessagesに渡す
・messages.vueでpropsメソッドで渡されたmessageを取得
　v-forでmessagesをコンポーネントmessageの渡す
・message.vueで同様にpropsメソッドで取得
　{{ message.text }}で表示

入力フォーム
・ChatForm.vueで、dataメソッドないで、textを設定（初期値はnull)
  　- addMessageメソッドを定義して、addメソッドでデータを追加する処理を書く（入力後はnullにする）
　- keyDownedForJPConversion メソッドを定義して、日本語入力の際に発火するイベントkeydown.enter上で
日本語変換時と送信時に同様のenterキーを利用する問題に対して、変換（キーボード番号229）の方が押された時の条件をかく
　- addMessageメソッドで、keyDownedForJPConversion メソッドないで、書いた条件に当てはまる場合は,returnするようにした
　- HTML上では、JS <=> HTML の双方向のデータバインディングを可能にするv-modelというのを使った
　- イベントに関しては、v-onでaddMessageメソッドを指定
